### PR TITLE
Fix the bug

### DIFF
--- a/public/assets/js/canvas.js
+++ b/public/assets/js/canvas.js
@@ -91,13 +91,15 @@ function onMouseDown(e) {
 }
 
 function onMouseUp(e) {
-  isDrawing = false;
-  let endX = e.offsetX;
-  let endY = e.offsetY;
-  currentPath.push([endX, endY]);
-  paths.push(new DrawingElement(tool, ctx.strokeStyle, currentPath));
-  currentPath = null;
-  drawPaths(paths);
+  if (isDrawing) {
+    isDrawing = false;
+    let endX = e.offsetX;
+    let endY = e.offsetY;
+    currentPath.push([endX, endY]);
+    paths.push(new DrawingElement(tool, ctx.strokeStyle, currentPath));
+    currentPath = null;
+    drawPaths(paths);
+  }
 }
 
 function drawPaths(paths) {


### PR DESCRIPTION
Prior to this change clicking and holding down outside the canvas,
moving the mouse over the canvas and then releasing would cause
an error. Resolves #43 