### PR TITLE
Update, create new, and delete

### DIFF
--- a/controllers/drawingsController.js
+++ b/controllers/drawingsController.js
@@ -96,8 +96,29 @@ router.post('/api/drawings', async (req, res) => {
   }
 });
 
-router.post('/api/drawings/:id', async (req, res) => {
-  // does this route make sense to include?
+router.put('/api/drawings/:id', async (req, res) => {
+  const { name, link, data, userId } = req.body;
+  const updatedDrawing = {
+    name,
+    link,
+    data,
+    UserId: userId,
+  };
+
+  try {
+    const drawing = await db.Drawing.update(updatedDrawing, { where: { id: req.params.id }});
+    res.json({
+      error: false,
+      message: 'Drawing updated.',
+      drawing,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({
+      error: true,
+      message: "Couldn't update the drawing.",
+    });
+  }
 });
 
 router.delete('/api/drawings/:id', async (req, res) => {

--- a/models/Drawings.js
+++ b/models/Drawings.js
@@ -7,8 +7,8 @@ module.exports = function (sequelize, DataTypes) {
         len: [1, 50],
       },
     },
-    link: { type: DataTypes.TEXT, allowNull: false },
-    data: { type: DataTypes.TEXT, allowNull: false },
+    link: { type: DataTypes.TEXT('medium'), allowNull: false },
+    data: { type: DataTypes.TEXT('medium'), allowNull: false },
   });
 
   Drawing.associate = function (models) {

--- a/public/assets/js/canvas.js
+++ b/public/assets/js/canvas.js
@@ -1,6 +1,7 @@
 import DrawingElement from './DrawingElement.js';
 
 const toolbar = document.querySelector('.toolbar');
+const ownerControls = document.querySelector('.owner-controls');
 const colorInput = document.querySelector('#color');
 const c = document.querySelector('canvas#main');
 const ctx = c.getContext('2d');
@@ -28,6 +29,29 @@ if (paths.length != 0) {
 colorInput.addEventListener('input', (e) => {
   ctx.strokeStyle = e.target.value;
 });
+
+if (ownerControls != null) {
+  const drawingId = ownerControls.getAttribute('data-drawingid');
+  const userId = ownerControls.getAttribute('data-userid');
+  ownerControls.addEventListener('click', (e) => {
+    if (e.target.matches('#owner-save')) {
+      const pathData = JSON.stringify(paths);
+      const drawingName = document.querySelector('#drawingName').value;
+      const link  = c.toDataURL();
+      $.ajax(`/api/drawings/${drawingId}`, {
+        method: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify({ name: drawingName, link, data: pathData, userId }),
+      }).then(response => {
+        console.log(response);
+      }).catch((error) => {
+        // TODO: Actually handle any error.
+      });
+    } else if (e.target.matches('#owner-delete')) {
+      console.log('owner delete clicked');
+    }
+  });
+}
 
 toolbar.addEventListener('click', (e) => {
   if (e.target.matches('#save')) {

--- a/public/assets/js/canvas.js
+++ b/public/assets/js/canvas.js
@@ -48,7 +48,17 @@ if (ownerControls != null) {
         // TODO: Actually handle any error.
       });
     } else if (e.target.matches('#owner-delete')) {
-      console.log('owner delete clicked');
+      const willDelete = confirm("Are you sure? This can't be undone!");
+      if (willDelete) {
+        $.ajax(`/api/drawings/${drawingId}`, {
+          method: 'DELETE'
+        }).then((response) => {
+          // Temporary. Where should we actually navigate to?
+          location.href = '/';
+        }).catch((error) => {
+          // TODO: Actually handle any error.
+        });
+      }
     }
   });
 }

--- a/server.js
+++ b/server.js
@@ -19,8 +19,8 @@ app.use(session({ secret: "canvas", resave: false, saveUninitialized: false }));
 
 const PORT = process.env.PORT || 8080;
 
-app.use(express.urlencoded({ extended: true }));
-app.use(express.json());
+app.use(express.urlencoded({ extended: true, limit: '1gb' }));
+app.use(express.json({ limit: '1gb'}));
 
 app.use(express.static('public'));
 

--- a/views/edit-artwork.handlebars
+++ b/views/edit-artwork.handlebars
@@ -3,14 +3,17 @@
 <div class="container">
   <h1>Edit Artwork</h1>
   {{#if owner }}
-    <button>Delete</button>
+    <div class="owner-controls" data-userid="{{ user.id }}" data-drawingid="{{ drawing.id }}">
+      <button id="owner-delete">Delete</button>
+      <button id="owner-save">Update</button>
+    </div>
   {{/if}}
   <div class="toolbar">
     <input class="button" type="color" name="color" id="color" />
     <button class="button" data-tool="line">line</button>
     <button class="button" data-tool="square">square</button>
     <button class="button" data-tool="pen">pen</button>
-    <button class="button" id="save" data-userid="{{ user.id }}">Save</button>
+    <button class="button" id="save" data-userid="{{ user.id }}">Save New</button>
     <button class="button" id="undo">Undo</button>
     <button class="button" id="redo">Redo</button>
   </div>


### PR DESCRIPTION
This PR expands on functionality for the drawing view page.

If the logged in user is the owner of the drawing they are viewing they'll be presented with additional controls for updating the drawing or deleting it, along with saving as a new drawing. If they are not the owner they will only be able to save as a new drawing.

`server.js` changes were required to allow bigger POST bodies so updating/creating drawings would work properly.
Changes to the Drawings model were part of this as well.